### PR TITLE
Update number of validators for networkBaseStake

### DIFF
--- a/apps/delegation-api/src/modules/delegation/delegation-apr.service.ts
+++ b/apps/delegation-api/src/modules/delegation/delegation-apr.service.ts
@@ -72,12 +72,12 @@ export class DelegationAprService {
       (1 - protocolSustainabilityRewards) * rewardsPerEpoch;
     const topUpRewardsLimit =
       0.5 * rewardsPerEpochWithoutProtocolSustainability;
-    const networkBaseStake = networkStake.ActiveValidators * stakePerNode;
+    const networkBaseStake = networkStake.TotalValidators * stakePerNode;
     const networkTotalStake = parseInt(denominateValue(stakedBalance.toFixed()));
 
     const networkTopUpStake =
       networkTotalStake -
-      networkStake.TotalValidators * stakePerNode -
+      networkBaseStake -
       networkStake.QueueSize * stakePerNode;
 
     const topUpReward =


### PR DESCRIPTION
##Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- The APR calculation was using the `activeValidators` count from Elrond API, which is not ok since that metric uses the heartbeat to figure out the online nods. For the APR we need to take into account the total number of nodes for the baseStake.

## Proposed Changes
- use `totalValidators` instead.

## How to test
- Check that the APR is the correct one, event when some nodes are offline